### PR TITLE
Add per-client property for channels

### DIFF
--- a/addon/services/socket-guru.js
+++ b/addon/services/socket-guru.js
@@ -16,6 +16,7 @@ const {
   getOwner,
   Evented,
   isArray,
+  runInDebug,
 } = Ember;
 
 export default Service.extend(Evented, {
@@ -83,8 +84,8 @@ export default Service.extend(Evented, {
    */
   setup() {
     const socketClient = get(this, 'socketClientLookup')(getOwner(this), get(this, 'socketClient'));
-    this._checkOptions();
     set(this, 'client', socketClient);
+    runInDebug(() => this._checkOptions());
     get(this, 'client').setup(
       get(this, 'config'),
       this._handleEvent.bind(this)
@@ -163,6 +164,6 @@ export default Service.extend(Evented, {
   },
 
   _hasNoChannels() {
-    return get(this, 'socketClient') === 'socketio';
+    return !!get(this, 'client.hasNoChannels');
   },
 });

--- a/addon/socket-clients/action-cable.js
+++ b/addon/socket-clients/action-cable.js
@@ -7,6 +7,7 @@ export default Ember.Object.extend({
   actionCable: null,
   eventHandler: null,
   joinedChannels: null,
+  hasNoChannels: true,
 
   setup(config, eventHandler) {
     assert(

--- a/addon/socket-clients/socketio.js
+++ b/addon/socket-clients/socketio.js
@@ -4,6 +4,8 @@ const { get, getProperties, assert, setProperties } = Ember;
 
 export default Ember.Object.extend({
   ioService: io,
+  hasNoChannels: true,
+
   // There's no concept of unsubscribing channels in socket.io
   unsubscribeChannels() {},
 


### PR DESCRIPTION
Closes #44 

A future cleanup would be a base socket-client that enforces required functions/properties

## Unresolved questions

- [ ] Docs update required?