### PR TITLE
Make sure to pass options to underlying services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Master
+- [BUGFIX] make sure to pass the options to underlying services (#43)

--- a/addon/socket-clients/pusher.js
+++ b/addon/socket-clients/pusher.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { omit } from 'lodash';
 
 const {
   get, set, setProperties, $, run, assert, warn,
@@ -9,6 +10,7 @@ export default Ember.Object.extend({
   socketId: null,
   socket: null,
   eventHandler: null,
+  requiredConfigurationOptions: ['pusherKey'],
   joinedChannels: {},
 
   setup(config, eventHandler) {
@@ -16,7 +18,10 @@ export default Ember.Object.extend({
     this._checkConfig(config);
     setProperties(this, {
       eventHandler,
-      socket: new PusherService(get(config, 'pusherKey'), config),
+      socket: new PusherService(
+        get(config, 'pusherKey'),
+        omit(config, get(this, 'requiredConfigurationOptions'))
+      ),
     });
 
     get(this, 'socket').connection

--- a/addon/socket-clients/socketio.js
+++ b/addon/socket-clients/socketio.js
@@ -1,17 +1,27 @@
 import Ember from 'ember';
+import { omit } from 'lodash';
 
-const { get, getProperties, assert, setProperties } = Ember;
+const {
+  get,
+  assert,
+  getProperties,
+  setProperties,
+  getWithDefault,
+} = Ember;
 
 export default Ember.Object.extend({
   ioService: io,
   hasNoChannels: true,
-
+  requiredConfigurationOptions: ['host'],
   // There's no concept of unsubscribing channels in socket.io
   unsubscribeChannels() {},
 
   setup(config, eventHandler) {
     this._checkConfig(config);
-    const socket = get(this, 'ioService')(get(config, 'host'));
+    const socket = get(this, 'ioService')(
+      get(config, 'host'),
+      omit(config, get(this, 'requiredConfigurationOptions'))
+    );
     setProperties(this, { socket, eventHandler });
     socket.connect();
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-lodash": "4.17.4",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "2.0.2",
     "ember-sinon": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "deploy": "ember github-pages:commit -m \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push origin gh-pages:gh-pages; git checkout master"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "ember-lodash": "4.17.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -58,7 +59,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-lodash": "4.17.4",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "2.0.2",
     "ember-sinon": "0.6.0",

--- a/tests/dummy/app/templates/components/docs-getting-started.hbs
+++ b/tests/dummy/app/templates/components/docs-getting-started.hbs
@@ -4,7 +4,9 @@
 <p>There are few things that have to be provided in order for the addon to work properly:</p>
 <ul>
   <li><code>socketClient</code>: string name of the socket client you want to use. See {{link-to "Socket Clients" "technology.socket-clients"}} for list of available options.</li>
-  <li><code>config</code>: this hash should contain all required configuration for the used client (for more info see {{link-to "Socket Clients" "technology.socket-clients"}} for documentation for specific clients)</li>
+  <li><code>config</code>: this hash should contain all required configuration for the used client (for more info see {{link-to "Socket Clients" "technology.socket-clients"}} for documentation for specific clients).
+    You can also pass all client-specific configuration options here.
+  </li>
   <li><code>observedChannels</code>: those are the channels and events that you want to listen to (see {{link-to "Observed Channels Structure" "technology.observed-channels-structure"}} for more info)</li>
 </ul>
 <h3>Usage</h3>

--- a/tests/unit/socket-clients/socketio-test.js
+++ b/tests/unit/socket-clients/socketio-test.js
@@ -46,10 +46,16 @@ test('setup function', function(assert) {
     ioService: ioStub,
   });
 
-  client.setup({ host: 'http://localhost:1234' }, eventHandlerSpy);
+  const clientOptions = { foo: 'bar' };
+
+  client.setup(
+    { host: 'http://localhost:1234', ...clientOptions },
+    eventHandlerSpy
+  );
 
   assert.ok(ioStub.calledOnce);
-  assert.equal(ioStub.args[0][0], 'http://localhost:1234');
+  assert.equal(ioStub.firstCall.args[0], 'http://localhost:1234');
+  assert.deepEqual(ioStub.firstCall.args[1], clientOptions, 'it passes client options to socketio');
   assert.ok(connectSpy.calledOnce);
   assert.equal(get(client, 'eventHandler'), eventHandlerSpy);
 });


### PR DESCRIPTION
Resolves #43.

We already passed in options for the pusher library (however, in this case, we also passed `pusherKey` which is not needed), but alas missed it in the `socketio` case.

For ActionCable nothing changed since you cannot pass any options to it.