### PR TITLE
Add support for providing connection params like a token

### DIFF
--- a/addon/socket-clients/phoenix.js
+++ b/addon/socket-clients/phoenix.js
@@ -12,7 +12,8 @@ export default Ember.Object.extend({
   setup(config, eventHandler) {
     this._checkConfig(config);
     const SocketService = get(this, 'Socket');
-    const socket = new SocketService(get(config, 'socketAddress'));
+    const connectParams = get(config, 'connectParams') || {};
+    const socket = new SocketService(get(config, 'socketAddress'), { params: connectParams });
     socket.connect();
     setProperties(this, { socket, eventHandler });
   },


### PR DESCRIPTION
Often when we want to connect to the server, we want to pass tokens (like JWT), so we can authenticate the socket.

This patch adds the ability to send any parameters to the server on connection initiation. We've been using it in production for 6 months now, connecting to a Elixir/Phoenix project.